### PR TITLE
Back buttons

### DIFF
--- a/app/models/licensee.rb
+++ b/app/models/licensee.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Licensee < ApplicationRecord
-  has_many :placements
+  has_many :placements, dependent: :destroy
   has_many :comments, through: :placements
 end

--- a/app/views/licensees/_form.html.erb
+++ b/app/views/licensees/_form.html.erb
@@ -1,5 +1,5 @@
 
-<div class='card bg-light col-8 rounded mb-0 shadow-sm mx-auto'>
+<div class='card bg-light col-8 rounded mb-2 shadow-sm mx-auto'>
     <div class='card-body'>
     <%= form_for @licensee do |f| %>
     <div>
@@ -32,4 +32,7 @@
     <% end %>
     </div>
 </div>
-<p></p>
+
+<div class='text-center'>
+    <%= link_to "Back", :back, class: 'btn btn-primary mt-2' %>
+</div>

--- a/app/views/licensees/show.html.erb
+++ b/app/views/licensees/show.html.erb
@@ -32,6 +32,9 @@
                             <%= link_to placement.name, placement_path(placement.id), class: 'border-bottom border-primary font-weight-bold' %><br>
                             <%= placement.address %><br>
                             <%= placement.city %>, <%= placement.state %> <%= placement.zip %>
+                            <div>
+                                <%= link_to 'Add Placement to Cart', add_carts_path(placement_id: placement.id, search: params[:search]), method: :post, class: 'btn btn-primary mt-2' %>
+                            </div>
                         </li>
                     </ul>
                         <% if current_user && current_user.admin? %><br>

--- a/app/views/licensees/show.html.erb
+++ b/app/views/licensees/show.html.erb
@@ -15,7 +15,7 @@
         <% if current_user && current_user.admin? %>
             <div>
                 <%= link_to 'Edit', edit_licensee_path(params[:id]), class: 'btn btn-primary' %>
-                <%= link_to 'Delete', licensee_path(params[:id]), method: :delete, :data => {:confirm => "Are you sure? This will also delete all placements associated with this Licensee."}, class: 'btn btn-danger ml-2' %>
+                <%= link_to 'Delete', licensee_path(params[:id]), method: :delete, :data => {:confirm => "Are you sure? IMPORTANT: This will also delete all placements associated with this Licensee!"}, class: 'btn btn-danger ml-2' %>
             </div>
         <% end %>
     </div>

--- a/app/views/licensees/show.html.erb
+++ b/app/views/licensees/show.html.erb
@@ -15,7 +15,7 @@
         <% if current_user && current_user.admin? %>
             <div>
                 <%= link_to 'Edit', edit_licensee_path(params[:id]), class: 'btn btn-primary' %>
-                <%= link_to 'Delete', licensee_path(params[:id]), method: :delete, :data => {:confirm => "Are you sure?"}, class: 'btn btn-danger ml-2' %>
+                <%= link_to 'Delete', licensee_path(params[:id]), method: :delete, :data => {:confirm => "Are you sure? This will also delete all placements associated with this Licensee."}, class: 'btn btn-danger ml-2' %>
             </div>
         <% end %>
     </div>

--- a/app/views/licensees_imports/new.html.erb
+++ b/app/views/licensees_imports/new.html.erb
@@ -39,3 +39,7 @@
     <% end %>
   </div>
 </div>
+
+<div class='text-center'>
+    <%= link_to "Back", :back, class: 'btn btn-primary mt-2' %>
+</div>

--- a/app/views/placements/_form.html.erb
+++ b/app/views/placements/_form.html.erb
@@ -1,5 +1,5 @@
 
-<div class='card bg-light col-8 rounded mb-0 shadow-sm mx-auto'>
+<div class='card bg-light col-8 rounded mb-2 shadow-sm mx-auto'>
     <div class='card-body'>
         <%= form_for @placement do |f| %>
     <div>
@@ -39,4 +39,7 @@
     </div>
 </div>
 
+<div class='text-center'>
+    <%= link_to "Back", :back, class: 'btn btn-primary mt-2' %>
+</div>
     

--- a/app/views/placements/index.html.erb
+++ b/app/views/placements/index.html.erb
@@ -6,7 +6,7 @@
 
 
 
-  <div class='card bg-light col-10 rounded mb-0 shadow-sm mx-auto'>
+  <div class='card bg-light col-10 rounded mb-2 shadow-sm mx-auto'>
     <div class='card-body'>
         <form action="/" method="get">
           <div class='row form-group'>
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class='text-center'>
-    <%= link_to 'Clear Search', placements_path, class: 'btn btn-primary mt-2' %>
+    <%= link_to 'Clear Search', placements_path, class: 'btn btn-primary mt-2 mb-2' %>
   </div>
 
 

--- a/app/views/placements/show.html.erb
+++ b/app/views/placements/show.html.erb
@@ -4,19 +4,22 @@
 <div class='shadow-sm card bg-light col-8 rounded mb-2 mx-auto'>
     <div class='card-body'>
         <h2><%= @placement.name %></h2>
-        <ul class='list-group shadow'>
+        <ul class='list-group shadow mb-2'>
             <li class='list-group-item'><%= @placement.address %></li>
             <li class='list-group-item'><%= @placement.city %>, <%= @placement.state %> <%= @placement.zip %></li>
             <li class='list-group-item'>County: <%= @placement.county %></li>
             <li class='list-group-item'>Placement Phone: <%= @placement.phone %></li>
         </ul>
+        <div>
+            <%= link_to 'Add Placement to Cart', add_carts_path(placement_id: @placement.id), method: :post, class: 'btn btn-primary mt-2' %>
+        </div>
     </div>
 </div>
 
 <div class='shadow-sm card bg-light col-8 rounded mb-2 mx-auto'>
     <div class='card-body'>
         <h5>To refer a potential resident, contact:</h5>
-        <ul class='list-group shadow'>
+        <ul class='list-group shadow mb-2'>
             <li class='list-group-item'><%= @licensee.contact_name %></li>
             <li class='list-group-item'>Phone: <%= @licensee.phone %></li>
             <li class='list-group-item'>Fax: <%= @licensee.fax %></li>
@@ -29,15 +32,14 @@
 <div class='shadow-sm card bg-light col-8 rounded mb-5 mx-auto'>
     <div class='card-body'>
         <h4>Other</h4>
-        <ul class='list-group shadow'>
+        <ul class='list-group shadow mb-2'>
             <li class='list-group-item'>Gender: <%= @placement.gender %></li>
             <li class='list-group-item'>Beds: <%= @placement.beds %></li>
         </ul>
-        <br>
         <% if current_user && current_user.admin? %>
-            <%= link_to 'Edit', edit_placement_path(@placement), class: 'btn btn-primary' %> 
+            <%= link_to 'Edit', edit_placement_path(@placement), class: 'btn btn-primary mt-2' %> 
         
-            <%= link_to 'Delete Placement', placement_path(@placement), method: :delete, :data => {:confirm => "Are you sure?"}, class: 'btn btn-danger ml-2' %>
+            <%= link_to 'Delete Placement', placement_path(@placement), method: :delete, :data => {:confirm => "Are you sure?"}, class: 'btn btn-danger ml-2 mt-2' %>
         <% end %>
     </div>
 </div>

--- a/app/views/placements_imports/new.html.erb
+++ b/app/views/placements_imports/new.html.erb
@@ -39,3 +39,7 @@
     <% end %>
   </div>
 </div>
+
+<div class='text-center'>
+    <%= link_to "Back", :back, class: 'btn btn-primary mt-2' %>
+</div>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -55,7 +55,7 @@
 
 <div class='text-center'>
   <% if current_user && current_user.admin? %>
-    <%= button_to "Delete Account", admin_path(current_user), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger mt-2' %></p>
+    <%= button_to "Delete Account", admin_path(current_user), data: { confirm: "Are you sure? This cannot be undone." }, method: :delete, class: 'btn btn-danger mt-2' %></p>
   <% end %>
   
   <%= link_to "Back", :back, class: 'btn btn-primary mb-2' %>


### PR DESCRIPTION
@jrmcgarvey I added some back buttons and updated confirm messages. There was an issue where licensees could be deleted and the placements associated with them would still be there without a licensee. I made a dependent destroy that would delete the associated placements too when a licensee was deleted. I also made the confirm popup message show that the placements would be deleted too if they deleted the licensee. This fix seems to work, but I don't know if that would be the best way to handle that. 