### PR TITLE
remove unused cart attribute status

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -5,11 +5,10 @@ class CartsController < ApplicationController
   before_action :create_new_cart, only: [:show, :add]
 
   def create_new_cart
-    @cart = Cart.find_by(user_id: current_user.id, status: 'Pending')
+    @cart = Cart.find_by(user_id: current_user.id)
     if @cart.nil?
       @cart = Cart.new
       @cart.user_id = current_user.id
-      @cart.status = 'Pending'
       @cart.save
     end
   end
@@ -35,15 +34,14 @@ class CartsController < ApplicationController
   end
 
   def remove
-    @cart = Cart.find_by(user_id: current_user.id, status: 'Pending')
+    @cart = Cart.find_by(user_id: current_user.id)
     cart_placement = CartPlacement.find(params[:placement_id])
     cart_placement.destroy
     redirect_to cart_path(current_user)
   end
 
   def submit
-    @cart = Cart.find_by(user_id: current_user.id, status: 'Pending')
-    @cart.status = 'Submitted'
+    @cart = Cart.find_by(user_id: current_user.id)
     @cart.save
     redirect_to root_path
   end
@@ -55,7 +53,7 @@ class CartsController < ApplicationController
   end
 
   def index
-    @cart = Cart.find_by(user_id: current_user.id, status: 'Pending')
+    @cart = Cart.find_by(user_id: current_user.id)
     respond_to do |format|
       format.xlsx do
         response.headers[

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -38,7 +38,7 @@ en:
       updated_not_active: "Your password has been changed successfully."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
+      signed_up: "You have successfully created a new account."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."

--- a/db/migrate/20190415143052_remove_status_from_carts.rb
+++ b/db/migrate/20190415143052_remove_status_from_carts.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromCarts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :carts, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_25_021030) do
+ActiveRecord::Schema.define(version: 2019_04_15_143052) do
 
   create_table "cart_placements", force: :cascade do |t|
     t.integer "cart_id"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 2019_03_25_021030) do
 
   create_table "carts", force: :cascade do |t|
     t.integer "user_id"
-    t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_carts_on_user_id"


### PR DESCRIPTION
@jrmcgarvey We had an unnecessary attribute in the create carts model, status. I added a migration to remove the attribute, and updated actions in the carts controller to reflect this. Also, I changed what a flash message would say when creating a new account. Please review.